### PR TITLE
feat: support single file > 4GB

### DIFF
--- a/src/code/helper.py
+++ b/src/code/helper.py
@@ -109,7 +109,8 @@ class StreamZipFile(zipfile.ZipFile):
         zinfo.file_size = file_size
         
         # Write updated header info, Write CRC and file sizes after the file data
-        fmt = '<LLLL'
+        # <QQQQ corresponds to C language's unsigned long long, supporting a single file > 4GB.
+        fmt = '<QQQQ'
         self.fp.write(struct.pack(fmt, zipfile._DD_SIGNATURE, zinfo.CRC,
                                   zinfo.compress_size, zinfo.file_size))
 


### PR DESCRIPTION
**Description**: In the StreamZipFile class, when writing zipInfo into a zip, if a single zipInfo corresponds to a file size >4GB, an error occurs while updating the zip file header. 
`struct.error: 'L' format requires 0 <= number <= 4294967295`
**Action**: This is because `<LLLL` indicates little-endian format, corresponding to the C data type 'unsigned long', which has a data range of 0 to 2^32-1=4294967295 on a 32-bit system. Changing it to `<QQQQ` can resolve the issue.

